### PR TITLE
call listenTo from the component and not the _ev object.

### DIFF
--- a/lib/Component.js
+++ b/lib/Component.js
@@ -331,8 +331,8 @@ _.extend(Framework.Component.prototype, {
 
 
 	// These seem to be required by Backbone core
-	listenTo: _disableLocalEventDelegator,
-	listenToOnce: _disableLocalEventDelegator
+	// listenTo: _disableLocalEventDelegator,
+	// listenToOnce: _disableLocalEventDelegator
 	// stopListening: _disableLocalEventDelegator
 
 });
@@ -365,9 +365,9 @@ _.extend(Framework.Component.prototype, {
 		if (this.collection) {
 
 			// Listen to events
-			this._ev.listenTo(this.collection, 'add', this.afterAdd);
-			this._ev.listenTo(this.collection, 'remove', this.afterRemove);
-			this._ev.listenTo(this.collection, 'reset', this.afterReset);
+			this.listenTo(this.collection, 'add', this.afterAdd);
+			this.listenTo(this.collection, 'remove', this.afterRemove);
+			this.listenTo(this.collection, 'reset', this.afterReset);
 		}
 
 		if (this.model) {
@@ -376,11 +376,11 @@ _.extend(Framework.Component.prototype, {
 			// e.g.
 			// .afterChange(model, options)
 			//
-			this._ev.listenTo(this.model, 'change', function (model, options) {
+			this.listenTo(this.model, 'change', function (model, options) {
 				if (_.isFunction(this.afterChange)) {
 					this.afterChange(model, options);
 				}
-			}, this);
+			});
 
 			// Listen for specific attribute changes
 			// e.g.


### PR DESCRIPTION
This fixes the context of the handler of collection and model changes.
